### PR TITLE
Fixes #9: convert exceptions to stream.error

### DIFF
--- a/lib/NgifyStreamReader.js
+++ b/lib/NgifyStreamReader.js
@@ -50,9 +50,14 @@ NgifyStreamReader.prototype._getOutput = function(){
  * @param stream The stream upon which the queue method can be called
  */
 NgifyStreamReader.prototype.end = function (stream) {
-    var output = this._getOutput();
-    stream.queue(output);
-    stream.queue(null);
+    try {
+        var output = this._getOutput();
+        stream.queue(output);
+        stream.queue(null);
+    }
+    catch (e) {
+        stream.emit('error', e);
+    }
 };
 
 module.exports = NgifyStreamReader;

--- a/spec/NgifyStreamReader.spec.js
+++ b/spec/NgifyStreamReader.spec.js
@@ -8,7 +8,6 @@ describe('NgifyStreamReader', function () {
         stream={},
         queue;
 
-
     beforeEach(function () {
         defaultReader = new NgifyStreamReader('/test/index.html');
         defaultReaderInvalid = new NgifyStreamReader('/test/index.js');
@@ -21,7 +20,7 @@ describe('NgifyStreamReader', function () {
         queue = [];
         stream.queue = function(chunk) {
             queue.push(chunk);
-        }
+        };
     });
 
     it('is valid for files with .html extension by default', function () {
@@ -59,5 +58,13 @@ describe('NgifyStreamReader', function () {
         defaultReader.write(stream, chunk);
         defaultReader.end(stream);
         expect(queue[0].indexOf('<div> test </div>')).toBeGreaterThan(-1);
+    });
+
+    it('emits an error event when given invalid HTML', function () {
+        stream.emit = jasmine.createSpy('emit');
+        var chunk = '<div';
+        defaultReader.write(stream, chunk);
+        defaultReader.end(stream);
+        expect(stream.emit).toHaveBeenCalledWith('error', jasmine.any(String));
     });
 });


### PR DESCRIPTION
Wrap the output generation in an exception handler and emit error
notifications rather than allowing the exception to bubble out